### PR TITLE
Fix handling of infeasible solution

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -325,4 +325,4 @@ if __name__ == '__main__':
     if sample is not None:
         soln, partitions = process_sample(sample, G, k)
 
-    visualize_results(G, partitions, soln)
+        visualize_results(G, partitions, soln)


### PR DESCRIPTION
Prevent exception being raised by trying to make use of undefined variables `soln` and `partitions`