### PR TITLE
Minor fixes to argument validation

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -75,8 +75,8 @@ def build_graph(args):
         print("\nBuilding partition graph...")
         k = args.k_partition
         if args.nodes % k != 0:
-            print("\nNumber of nodes must be divisible by k. Adjusted number of nodes to {}.".format(n))
             n = int(args.nodes/k)*k
+            print("\nNumber of nodes must be divisible by k. Adjusted number of nodes to {}.".format(n))
         else:
             n = args.nodes
         G = nx.random_partition_graph([int(n/k)]*k, args.p_in, args.p_out)


### PR DESCRIPTION
A couple of minor fixes to argument validation:
- Message about "Number of nodes must be divisible by k.  Adjusted number of nodes to..." was being always shown.
- Modification to number of nodes in case of `args.nodes < 1` was missing, even though message was shown.

These issues could be avoided by changing the logic of the argument parsing to raise an exception on invalid input, instead of trying to modify it, as mentioned in #14. 