### PR TITLE
Change one-hot constraints to use discrete variables

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -121,13 +121,14 @@ def build_cqm(G, k):
 
     # Add binary variables, one for each node and each partition in the graph
     print("\nAdding variables....")
-    v = [[Binary(f'v_{i},{k}') for k in partitions] for i in G.nodes]   
+    v = [[Binary(f'v_{i},{k}') for k in partitions] for i in G.nodes]
+    labels = [[f'v_{i},{k}' for k in partitions] for i in G.nodes]
 
     # One-hot constraint: each node is assigned to exactly one partition
     print("\nAdding one-hot constraints...")
     for n in G.nodes:
         # print("\nAdding one-hot for node", n)
-        cqm.add_constraint(quicksum(v[n]) == 1, label='one-hot-node-{}'.format(n)) 
+        cqm.add_discrete(labels[n], label=f"one-hot-node-{n}")
 
     # Constraint: Partitions have equal size
     print("\nAdding partition size constraint...")
@@ -291,7 +292,7 @@ def main(graph, nodes, degree, prob, p_in, p_out, new_edges, k_partition):
 
     # Initialize the CQM solver
     print("\nOptimizing on LeapHybridCQMSampler...")
-    sampler = LeapHybridCQMSampler()
+    sampler = LeapHybridCQMSampler(solver='hybrid_constrained_quadratic_model_version1p')
     
     sample = run_cqm_and_collect_solutions(cqm, sampler)
     

--- a/demo.py
+++ b/demo.py
@@ -292,7 +292,7 @@ def main(graph, nodes, degree, prob, p_in, p_out, new_edges, k_partition):
 
     # Initialize the CQM solver
     print("\nOptimizing on LeapHybridCQMSampler...")
-    sampler = LeapHybridCQMSampler(solver='hybrid_constrained_quadratic_model_version1p')
+    sampler = LeapHybridCQMSampler()
     
     sample = run_cqm_and_collect_solutions(cqm, sampler)
     

--- a/demo.py
+++ b/demo.py
@@ -122,13 +122,12 @@ def build_cqm(G, k):
     # Add binary variables, one for each node and each partition in the graph
     print("\nAdding variables....")
     v = [[Binary(f'v_{i},{k}') for k in partitions] for i in G.nodes]
-    labels = [[f'v_{i},{k}' for k in partitions] for i in G.nodes]
 
     # One-hot constraint: each node is assigned to exactly one partition
     print("\nAdding one-hot constraints...")
-    for n in G.nodes:
-        # print("\nAdding one-hot for node", n)
-        cqm.add_discrete(labels[n], label=f"one-hot-node-{n}")
+    for i in G.nodes:
+        # print("\nAdding one-hot for node", i)
+        cqm.add_discrete([f'v_{i},{k}' for k in partitions], label=f"one-hot-node-{i}")
 
     # Constraint: Partitions have equal size
     print("\nAdding partition size constraint...")


### PR DESCRIPTION
Now that we have discrete variables in cqm I thought we could use them here. 

Is there a way to implement the partition size equality constraint using symbolic math + discrete variables? 